### PR TITLE
Fix "TypeError: 'NoneType'"

### DIFF
--- a/examples/WASD_flight.py
+++ b/examples/WASD_flight.py
@@ -26,7 +26,7 @@ if __name__ == '__main__':
             ch_5 = 2000
             frame = camera.get_frame()
             if frame is not None:
-                camera_frame = cv2.imdecode(np.frombuffer(camera.get_frame(), dtype=np.uint8),
+                camera_frame = cv2.imdecode(np.frombuffer(frame, dtype=np.uint8),
                                         cv2.IMREAD_COLOR)
                 cv2.imshow('pioneer_camera_stream', camera_frame)
             key = cv2.waitKey(1)


### PR DESCRIPTION
Fix "TypeError: a bytes-like object is required, not 'NoneType'" becase call camera.get_frame() is repeat without repeated check frame is not None